### PR TITLE
Set initial attempt count to 0

### DIFF
--- a/src/Shamiao/L4mysqlqueue/Queue/MysqlQueue.php
+++ b/src/Shamiao/L4mysqlqueue/Queue/MysqlQueue.php
@@ -125,7 +125,7 @@ class MysqlQueue extends Queue implements QueueInterface {
             'queue_name' => $queue, 
             'payload'  => $payload, 
             'status'   => 'pending', 
-            'attempts' => 1, 
+            'attempts' => 0, 
             'fireon'   => $time->getTimestamp(), 
         ]);
         return $jobId; 


### PR DESCRIPTION
When job is inserted to queue table, set the attempts to 0 instead of 1. When the $job->fire()  method runs, it +1's the attempts field before it processes the job.
